### PR TITLE
Change BannedConsts to BannedConstPatterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,9 @@ Check not to refer constants over dependency boundaries which given from `Rules`
 When the following `Rules` is given,
 
 ```yaml
-Rules:                      # Array of each rules
-  - BannedConsts: Foo       # Array<String> | String.
-    FromNamespacePatterns:  # Array<String> | String. This value is used as Regexp pattern.
+Rules:                        # Array of each rules
+  - BannedConstPatterns: Foo  # Array<String> | String. This value is used as Regexp pattern.
+    FromNamespacePatterns:    # Array<String> | String. This value is used as Regexp pattern.
       - \ABar(\W|\z)
 ```
 

--- a/lib/rubocop/cop/dependency/over_boundary.rb
+++ b/lib/rubocop/cop/dependency/over_boundary.rb
@@ -7,7 +7,7 @@ module RuboCop
       #
       # @example
       #   # Rules:
-      #   #   - BannedConsts: Foo
+      #   #   - BannedConstPatterns: Foo
       #   #     FromNamespacePatterns:
       #   #       - \ABar(\W|\z)
       #
@@ -18,6 +18,8 @@ module RuboCop
       #
       class OverBoundary < Base
         def on_const(node)
+          return if node.parent&.const_type?
+
           const_name = node.const_name
           current_namespace =
             node
@@ -27,7 +29,9 @@ module RuboCop
 
           if cop_config['Rules']
              .select { |rule|
-               Array(rule['BannedConsts']).include?(const_name)
+               Array(rule['BannedConstPatterns']).any? { |banned_pattern|
+                 Regexp.new(banned_pattern).match?(const_name)
+               }
              }
              .any? { |rule|
                Array(rule['FromNamespacePatterns']).any? { |from_pattern|

--- a/spec/rubocop/cop/dependency/over_boundary_spec.rb
+++ b/spec/rubocop/cop/dependency/over_boundary_spec.rb
@@ -170,6 +170,15 @@ RSpec.describe RuboCop::Cop::Dependency::OverBoundary, :config do
       RUBY
     end
 
+    it 'registers an offense when referring const `Bar::X` from class `Foo`' do
+      expect_offense(<<~RUBY)
+        class Foo
+          Bar::X.new
+          ^^^^^^ Const `Bar::X` cannot use from namespace `Foo`.
+        end
+      RUBY
+    end
+
     it 'does not registers an offense when referring const `X::Bar` from class `Foo`' do
       expect_no_offenses(<<~RUBY)
         class Foo

--- a/spec/rubocop/cop/dependency/over_boundary_spec.rb
+++ b/spec/rubocop/cop/dependency/over_boundary_spec.rb
@@ -158,7 +158,7 @@ RSpec.describe RuboCop::Cop::Dependency::OverBoundary, :config do
 
   context 'when complex Rules' do
     let(:cop_config) do
-      RuboCop::Config.new('Rules' => [{ 'BannedConstPatterns' => '\ABar\z', 'FromNamespacePatterns' => '\AFoo\z' }])
+      RuboCop::Config.new('Rules' => [{ 'BannedConstPatterns' => '\ABar', 'FromNamespacePatterns' => '\AFoo\z' }])
     end
 
     it 'registers an offense when referring const `Bar` from class `Foo`' do

--- a/spec/rubocop/cop/dependency/over_boundary_spec.rb
+++ b/spec/rubocop/cop/dependency/over_boundary_spec.rb
@@ -161,7 +161,7 @@ RSpec.describe RuboCop::Cop::Dependency::OverBoundary, :config do
       RuboCop::Config.new('Rules' => [{ 'BannedConstPatterns' => '\ABar', 'FromNamespacePatterns' => '\AFoo\z' }])
     end
 
-    it 'registers an offense when referring const `B` from expression of class `A`' do
+    it 'registers an offense when referring const `Bar` from class `Foo`' do
       expect_offense(<<~RUBY)
         class Foo
           Bar.new
@@ -170,7 +170,7 @@ RSpec.describe RuboCop::Cop::Dependency::OverBoundary, :config do
       RUBY
     end
 
-    it 'registers an offense when referring const `B` from expression of class `A`' do
+    it 'does not registers an offense when referring const `X::Bar` from class `Foo`' do
       expect_no_offenses(<<~RUBY)
         class Foo
           X::Bar.new
@@ -178,7 +178,7 @@ RSpec.describe RuboCop::Cop::Dependency::OverBoundary, :config do
       RUBY
     end
 
-    it 'registers an offense when referring const `B` from expression of class `A`' do
+    it 'does not registers an offense when referring const `Bar` from class `FooFoo`' do
       expect_no_offenses(<<~RUBY)
         class FooFoo
           Bar.new
@@ -186,7 +186,7 @@ RSpec.describe RuboCop::Cop::Dependency::OverBoundary, :config do
       RUBY
     end
 
-    it 'registers an offense when referring const `B` from expression of class `A`' do
+    it 'does not registers an offense when referring const `Bar` from class `Foo::X`' do
       expect_no_offenses(<<~RUBY)
         class Foo::X
           Bar.new
@@ -194,7 +194,7 @@ RSpec.describe RuboCop::Cop::Dependency::OverBoundary, :config do
       RUBY
     end
 
-    it 'registers an offense when referring const `B` from expression of class `A`' do
+    it 'does not registers an offense when referring const `Bar` from class `X::Foo`' do
       expect_no_offenses(<<~RUBY)
         class X::Foo
           Bar.new

--- a/spec/rubocop/cop/dependency/over_boundary_spec.rb
+++ b/spec/rubocop/cop/dependency/over_boundary_spec.rb
@@ -158,7 +158,7 @@ RSpec.describe RuboCop::Cop::Dependency::OverBoundary, :config do
 
   context 'when complex Rules' do
     let(:cop_config) do
-      RuboCop::Config.new('Rules' => [{ 'BannedConstPatterns' => '\ABar', 'FromNamespacePatterns' => '\AFoo\z' }])
+      RuboCop::Config.new('Rules' => [{ 'BannedConstPatterns' => '\ABar\z', 'FromNamespacePatterns' => '\AFoo\z' }])
     end
 
     it 'registers an offense when referring const `Bar` from class `Foo`' do

--- a/spec/rubocop/cop/dependency/over_boundary_spec.rb
+++ b/spec/rubocop/cop/dependency/over_boundary_spec.rb
@@ -3,7 +3,7 @@
 RSpec.describe RuboCop::Cop::Dependency::OverBoundary, :config do
   context 'when simple Rules' do
     let(:cop_config) do
-      RuboCop::Config.new('Rules' => [{ 'BannedConsts' => 'B', 'FromNamespacePatterns' => 'A' }])
+      RuboCop::Config.new('Rules' => [{ 'BannedConstPatterns' => 'B', 'FromNamespacePatterns' => 'A' }])
     end
 
     it 'registers an offense when referring const `B` from expression of class `A`' do
@@ -158,7 +158,7 @@ RSpec.describe RuboCop::Cop::Dependency::OverBoundary, :config do
 
   context 'when complex Rules' do
     let(:cop_config) do
-      RuboCop::Config.new('Rules' => [{ 'BannedConsts' => 'Bar', 'FromNamespacePatterns' => '\AFoo\z' }])
+      RuboCop::Config.new('Rules' => [{ 'BannedConstPatterns' => '\ABar', 'FromNamespacePatterns' => '\AFoo\z' }])
     end
 
     it 'registers an offense when referring const `B` from expression of class `A`' do


### PR DESCRIPTION
Changed the configuration to use `BannedConstPatterns` instead of `BannedConsts`.

BannedConstPatterns allows specifying patterns using regular expressions.

While this is a breaking change, it maintains compatibility with the previous configuration as follows:

BannedConsts|BannedConstPatterns
--|--
`Bar`|`\ABar`